### PR TITLE
serve bower components statically via express

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'app')));
+app.use('/bower_components',express.static(path.join(__dirname,'bower_components')));
 
 // angular
 app.get('/', function (req, res) {


### PR DESCRIPTION
The app doesn't find the bower assets correctly, so I added the '/bower_components' path to the express app middleware so they are served statically.